### PR TITLE
Remove NLog references from bincomp to allow for easy builds.

### DIFF
--- a/EnemizerLibrary/EnemizerLibrary.csproj
+++ b/EnemizerLibrary/EnemizerLibrary.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>6.1.0.210</Version>
+    <Version>6.1.0.212</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/bincomp/Program.cs
+++ b/bincomp/Program.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
-using NLog;
 
 namespace BinComp
 {
@@ -14,7 +13,7 @@ namespace BinComp
 	{
 		private static void Main(string[] args)
 		{
-			Logger.Debug("BinComp ---- ");
+			Console.WriteLine("BinComp ---- ");
 			if (args.Length != 3)
 			{
 				PrintUsage();
@@ -24,11 +23,11 @@ namespace BinComp
 			var asmFilename = args[0];
 			var basePatchJson = args[1];
 			var symbolsFilename = args[2];
-			Logger.Debug($"input asm: {asmFilename}");
-			Logger.Debug($"output file: {basePatchJson}");
-			Logger.Debug($"Exported Symbols: {symbolsFilename}");
+			Console.WriteLine($"input asm: {asmFilename}");
+			Console.WriteLine($"output file: {basePatchJson}");
+			Console.WriteLine($"Exported Symbols: {symbolsFilename}");
 
-			Logger.Debug($"Cleaning up for a fresh build attempt.");
+			Console.WriteLine($"Cleaning up for a fresh build attempt.");
 			File.Delete(basePatchJson);
 			File.Delete(symbolsFilename);
 
@@ -42,44 +41,44 @@ namespace BinComp
 			// ReSharper restore InconsistentNaming
 			// ReSharper restore JoinDeclarationAndInitializer
 
-			Logger.Debug($"temp file (zeros): {tempFile_0x00}");
-			Logger.Debug($"temp file (0xFF): {tempFile_0xFF}");
+			Console.WriteLine($"temp file (zeros): {tempFile_0x00}");
+			Console.WriteLine($"temp file (0xFF): {tempFile_0xFF}");
 
 			RunAsar(asmFilename, tempFile_0x00, symbolsFilename);
 
-			Logger.Debug("Reading all 0x00 file.");
+			Console.WriteLine("Reading all 0x00 file.");
 			FileStream fileStream = new FileStream(tempFile_0x00, FileMode.Open, FileAccess.Read);
 			patch_0x00 = new byte[fileStream.Length];
 			fileStream.Read(patch_0x00, 0, (int)fileStream.Length);
 			fileStream.Close();
-			Logger.Debug("Read all 0x00 file.");
+			Console.WriteLine("Read all 0x00 file.");
 
 
-			Logger.Debug("Generating all 0xFF file.");
+			Console.WriteLine("Generating all 0xFF file.");
 			fileStream = new FileStream(tempFile_0xFF, FileMode.CreateNew, FileAccess.Write);
 			patch_0xFF = Enumerable.Repeat(byte.MaxValue, patch_0x00.Length).ToArray();
 			fileStream.Write(patch_0xFF, 0, patch_0xFF.Length);
 			fileStream.Flush();
 			fileStream.Close();
-			Logger.Debug("Generated all 0xFF file.");
+			Console.WriteLine("Generated all 0xFF file.");
 
 			RunAsar(asmFilename, tempFile_0xFF, symbolsFilename);
 
-			Logger.Debug("Reading all 0xFF patched file.");
+			Console.WriteLine("Reading all 0xFF patched file.");
 			fileStream = new FileStream(tempFile_0xFF, FileMode.Open, FileAccess.Read);
 			patch_0xFF = new byte[fileStream.Length];
 			fileStream.Read(patch_0xFF, 0, (int)fileStream.Length);
 			fileStream.Close();
-			Logger.Debug("Read all 0xFF patched file.");
+			Console.WriteLine("Read all 0xFF patched file.");
 
 
 			if (patch_0x00.Length != patch_0xFF.Length)
 			{
-				Logger.Debug("File lengths don't match! Aborting.");
+				Console.WriteLine("File lengths don't match! Aborting.");
 				throw new Exception("file lengths don't match!");
 			}
 
-			Logger.Debug("");
+			Console.WriteLine("");
 			var list = new List<Patch>();
 			Patch patch = null;
 			var flag = true;
@@ -91,26 +90,26 @@ namespace BinComp
 					if (flag) 
 						continue;
 
-					Logger.Debug("Something went wrong. Zero file has non-zero or FF file has non-FF where files do not match!");
+					Console.WriteLine("Something went wrong. Zero file has non-zero or FF file has non-FF where files do not match!");
 					throw new Exception("Something went wrong. Zero file has non-zero or FF file has non-FF where files do not match!");
 				}
 
 				if (flag)
 				{
-					Logger.Debug($"New patch data found at address {i:X}");
+					Console.WriteLine($"New patch data found at address {i:X}");
 					flag = false;
 					patch = new Patch {address = i};
 					list.Add(patch);
 				}
 				patch.patchData.Add(patch_0x00[i]);
 			}
-			Logger.Debug("Writing patch data file.");
+			Console.WriteLine("Writing patch data file.");
 			File.WriteAllText(basePatchJson, JsonConvert.SerializeObject(list));
 
-			Logger.Debug("Cleaning up temp files.");
+			Console.WriteLine("Cleaning up temp files.");
 			File.Delete(tempFile_0x00);
 			File.Delete(tempFile_0xFF);
-			Logger.Debug("BinComp finished ----");
+			Console.WriteLine("BinComp finished ----");
 		}
 
 		private static void PrintUsage()
@@ -120,7 +119,7 @@ namespace BinComp
 
 		private static void RunAsar(string asmFilename, string romFilename, string symbolsFilename)
 		{
-			Logger.Debug($"---- Running asar --no-title-check --fix-checksum=off --symbols=wla --symbols-path={symbolsFilename} {asmFilename} {romFilename} ----");
+			Console.WriteLine($"---- Running asar --no-title-check --fix-checksum=off --symbols=wla --symbols-path={symbolsFilename} {asmFilename} {romFilename} ----");
 			using (Process process = new Process())
 			{
 				process.StartInfo.FileName = "asar.exe";
@@ -145,18 +144,15 @@ namespace BinComp
 					process.BeginOutputReadLine();
 					process.WaitForExit();
 					outputWaitHandle.WaitOne();
-					Logger.Debug(output.ToString());
+					Console.WriteLine(output.ToString());
 					if (process.ExitCode != 0)
 					{
-						Logger.Debug("asar threw errors");
+						Console.WriteLine("asar threw errors");
 						throw new Exception("asar threw errors");
 					}
 				}
 			}
-			Logger.Debug("---- asar finished ----");
+			Console.WriteLine("---- asar finished ----");
 		}
-
-		// Token: 0x04000001 RID: 1
-		private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 	}
 }


### PR DESCRIPTION
References #4 which this builds on top of. Bincomp didn't need the NLog references that were left over from decompilation. NLog is overkill for logging in a console app anyway.