### PR TITLE
Add Archipelago rom names

### DIFF
--- a/EnemizerLibrary/RomData.cs
+++ b/EnemizerLibrary/RomData.cs
@@ -307,8 +307,10 @@ namespace EnemizerLibrary
                     (0x56, 0x54), // item randomizer: VT
                     (0x45, 0x52), // entrance randomizer: ER
                     (0x42, 0x4D), // berserker's multiworld: BM
-            (0x42, 0x44), // berserker's multiworld doors: BD
-                    (0x44, 0x52)  // door randomizer: DR
+                    (0x42, 0x44), // berserker's multiworld doors: BD
+                    (0x44, 0x52), // door randomizer: DR
+                    (0x41, 0x50), // Archipelago: AP
+                    (0x41, 0x44)  // Archipelago with door rando: AD
                 };
 
                 foreach (var abbr in acceptableAbbreviations)


### PR DESCRIPTION
What I didn't do, but maybe should be considered, is removing some other accepted rom name types going forward as compatibility can't be guarenteed.